### PR TITLE
Fix incorrect p-value selection in plotting helpers

### DIFF
--- a/chess-mvpa/modules/plotting_helpers.py
+++ b/chess-mvpa/modules/plotting_helpers.py
@@ -259,7 +259,10 @@ def plot_mvpa_barplot(
         - line_center (list): List of tuples (line_x, line_y, line_lower, line_upper, group).
         - _ax (matplotlib.axes.Axes): Axis object for the plot.
         """
-        chosen_p="p_corrected" if use_corrected_p == True else "p_corrected"
+        # Select the appropriate p-value column depending on whether
+        # FDR-corrected statistics should be used. When `use_corrected_p`
+        # is False we fall back to the uncorrected p-values.
+        chosen_p = "p_corrected" if use_corrected_p else "p_uncorrected"
 
         try:
             line_x, line_y, group, facecolor = line_center


### PR DESCRIPTION
## Summary
- use uncorrected p values when plot_mvpa_barplot doesn't request FDR-corrected

## Testing
- `python -m py_compile chess-mvpa/modules/plotting_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_6845545f6c608324a5a0530894bb275e