### PR TITLE
Fix CI calc for correlation differences

### DIFF
--- a/chess-neurosynth/main_full.py
+++ b/chess-neurosynth/main_full.py
@@ -59,7 +59,7 @@ def main():
         # Compute all correlations and differences
         df_pos, df_neg, df_diff = compute_all_zmap_correlations(
             z_pos, z_neg, term_maps, ref_img,
-            n_boot=10000, fdr_alpha=0.05
+            n_boot=10000, fdr_alpha=0.05, ci_alpha=0.05
         )
 
         # Plot paired correlations


### PR DESCRIPTION
## Summary
- compute All Z map correlations: add `ci_alpha` parameter and update doc
- use `ci_alpha` to compute CI for correlation differences
- pass `ci_alpha` in `main_full.py`
- switch to bootstrap approach for difference CIs and p-values

## Testing
- `pytest -q`
- `python -m py_compile chess-neurosynth/main_full.py chess-neurosynth/modules/stats_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6846d3ee6cd08324a3e0ac32f8ce7129